### PR TITLE
Changed from using Subversion to Git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN usermod -u 99 nobody
 RUN usermod -g 100 nobody
 
 ADD sources.list /etc/apt/
-RUN add-apt-repository ppa:jon-severinsson/ffmpeg
+RUN add-apt-repository ppa:mc3man/trusty-media
 RUN apt-get update -qq
 RUN apt-get install -qy ffmpeg nzbget wget unrar unzip p7zip
 

--- a/edge.sh
+++ b/edge.sh
@@ -23,25 +23,12 @@ compile_libpar2(){
 
 if [[ -n $EDGE ]]; then
   echo "Compiling from source."
-  # Set SVN to version, revision or trunk
-  regex_version="[0-9]{2}\.[0-9]*?"
-  regex_revision="[0-9]{4}"
-  if [[ $EDGE =~ $regex_version ]]; then
-    SVN="svn://svn.code.sf.net/p/nzbget/code/tags/${EDGE}"
-    echo "Checking out version ${EDGE}"
-  elif [[ $EDGE =~ $regex_revision ]]; then
-    SVN="-r ${EDGE} svn://svn.code.sf.net/p/nzbget/code/trunk"
-    echo "Checking out revision $EDGE"
-  else
-    SVN="svn://svn.code.sf.net/p/nzbget/code/trunk"
-    echo "Checking out the trunk version"
-  fi
 
   # Install build dependencies
   {
     apt-get update -qq
     apt-get remove -y nzbget libpar2-1
-    apt-get install -qy libncurses5-dev sigc++ libssl-dev libxml2-dev sigc++ build-essential subversion
+    apt-get install -qy libncurses5-dev sigc++ libssl-dev libxml2-dev sigc++ build-essential git
   } &> /config/nzbget-${EDGE}-compile.log
 
   # Patch and compile libpar2
@@ -52,10 +39,14 @@ if [[ -n $EDGE ]]; then
   echo "Start building nzbget"
   {
     # Checkout the source code
-    svn checkout ${SVN} /tmp/nzbget-source
+    git clone https://github.com/nzbget/nzbget.git /tmp/nzbget-source
 
     # Build and install the source code
     cd /tmp/nzbget-source
+
+    # Checkout whatever branch/tag/commit was provided
+    git checkout $EDGE	
+
     ./configure --prefix=/usr --enable-parcheck
     make -j5
     make install


### PR DESCRIPTION
Seems like the Subversion repo of NZBGet doesn't have the latest dev version. This grabs the source files from Github instead of their SVN repo.

Still allows to use specific tags/branch/commits.